### PR TITLE
Fix mailchip popup

### DIFF
--- a/conference/index.html
+++ b/conference/index.html
@@ -710,7 +710,6 @@ s.parentNode.insertBefore(b, s);})();
 </noscript>
 
     <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/61b1323da1c42241d5d551eea/f71a99f5657b274cd4f31054b.js");</script>
-    <script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us10.list-manage.com","uuid":"61b1323da1c42241d5d551eea","lid":"72efe89850"}) })</script>
 </body>
 
 </html>


### PR DESCRIPTION
Mailchip popups could not be closed. The fix was to remove the duplicate embedding of the popup script